### PR TITLE
Added IP Long, IP Range, and RFC1918 Checks

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -58,5 +58,13 @@ class TestUB(unittest.TestCase):
         self.assertTrue(ub.ip_between("192.30.252.130", "1.1.1.1", "255.255.255.255"))
         self.assertFalse(ub.ip_between("192.30.252.130", "1.1.1.1", "255.255.255"))
 
+    def test_is_rfc1918(self):
+        self.assertIsInstance(ub.is_rfc1918("10.10.10.10"), bool)
+        self.assertTrue(ub.is_rfc1918("10.10.10.10"))
+        self.assertTrue(ub.is_rfc1918("172.16.10.10"))
+        self.assertTrue(ub.is_rfc1918("192.168.1.1"))
+        self.assertFalse(ub.is_rfc1918("172.15.10.10"))
+        self.assertFalse(ub.is_rfc1918("192.30.252.130"))
+
 if __name__ == '__main__':
     unittest.main()

--- a/utilitybelt.py
+++ b/utilitybelt.py
@@ -39,6 +39,16 @@ def ip_between(ip, start, finish):
     else:
         return False
 
+def is_rfc1918(ip):
+    if ip_between(ip, "10.0.0.0", "10.255.255.255"):
+        return True
+    elif ip_between(ip, "172.16.0.0", "172.31.255.255"):
+        return True
+    elif ip_between(ip, "192.168.0.0", "192.168.255.255"):
+        return True
+    else:
+        return False
+
 def is_IPv4Address(ipv4address):
     """Returns true for valid IPv4 Addresses, false for invalid."""
 


### PR DESCRIPTION
Ok, I got a bit carried away.
- You can now calculate the IP Long from an IP.
- You can give an IP to check, a start IP, and an end IP, and find out if the IP is between.
- You can check if an IP is in a RFC1918 block.

And tests to boot.
