### PR TITLE
Rename to avoid PyPI namespace collision

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 
 
 setup(
-    name="utilitybelt",
+    name="cnd-utilitybelt",
     version="0.1",
     description="Utilities to make you a CND Batman",
-    url="https://github.com/sroberts/utilitybelt",
+    url="https://github.com/yolothreat/utilitybelt",
     license="MIT",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This is actually already done. Submitting this pro forma to close #21.