### PR TITLE
adds function to get geolocation from domain names using round robin dns

### DIFF
--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -37,14 +37,14 @@ class TestUB(unittest.TestCase):
 
     def test_domain_to_mgeo(self):
         self.assertIsInstance(ub.domain_to_mgeo("github.com"), list)
-        self.assertEqual(ub.domain_to_geo("github.com")[0]["city"], 'San Francisco')
-        self.assertEqual(ub.domain_to_geo("github.com")[0]["region_code"], 'CA')
-        self.assertEqual(ub.domain_to_geo("github.com")[0]["country_name"], 'United States')
+        self.assertEqual(ub.domain_to_mgeo("github.com")[0]["city"], 'San Francisco')
+        self.assertEqual(ub.domain_to_mgeo("github.com")[0]["region_code"], 'CA')
+        self.assertEqual(ub.domain_to_mgeo("github.com")[0]["country_name"], 'United States')
         heroku = ub.domain_to_mgeo("heroku.com")
         self.assertIsInstance(heroku, list)
         self.assertTrue(len(heroku)>1)
         self.assertIsInstance(heroku[0], dict)
-        self.assertEqual(heroku[0]["city"], "Asburn")
+        self.assertEqual(heroku[0]["city"], "Ashburn")
         self.assertEqual(heroku[0]["region_code"], "VA")
         self.assertEqual(heroku[0]["country_name"], "United States")
 

--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -35,6 +35,19 @@ class TestUB(unittest.TestCase):
         self.assertEqual(ub.domain_to_geo("github.com")["region_code"], 'CA')
         self.assertEqual(ub.domain_to_geo("github.com")["country_name"], 'United States')
 
+    def test_domain_to_mgeo(self):
+        self.assertIsInstance(ub.domain_to_mgeo("github.com"), list)
+        self.assertEqual(ub.domain_to_geo("github.com")[0]["city"], 'San Francisco')
+        self.assertEqual(ub.domain_to_geo("github.com")[0]["region_code"], 'CA')
+        self.assertEqual(ub.domain_to_geo("github.com")[0]["country_name"], 'United States')
+        heroku = ub.domain_to_mgeo("heroku.com")
+        self.assertIsInstance(heroku, list)
+        self.assertTrue(len(heroku)>1)
+        self.assertIsInstance(heroku[0], dict)
+        self.assertEqual(heroku[0]["city"], "Asburn")
+        self.assertEqual(heroku[0]["region_code"], "VA")
+        self.assertEqual(heroku[0]["country_name"], "United States")
+
     def test_ip_to_geojson(self):
         self.assertIsInstance(ub.ip_to_geojson("192.30.252.130"), dict)
 

--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -51,14 +51,14 @@ class TestUB(unittest.TestCase):
 
     def test_domain_to_mgeo(self):
         self.assertIsInstance(ub.domain_to_mgeo("github.com"), list)
-        self.assertEqual(ub.domain_to_geo("github.com")[0]["city"], 'San Francisco')
-        self.assertEqual(ub.domain_to_geo("github.com")[0]["region_code"], 'CA')
-        self.assertEqual(ub.domain_to_geo("github.com")[0]["country_name"], 'United States')
+        self.assertEqual(ub.domain_to_mgeo("github.com")[0]["city"], 'San Francisco')
+        self.assertEqual(ub.domain_to_mgeo("github.com")[0]["region_code"], 'CA')
+        self.assertEqual(ub.domain_to_mgeo("github.com")[0]["country_name"], 'United States')
         heroku = ub.domain_to_mgeo("heroku.com")
         self.assertIsInstance(heroku, list)
         self.assertTrue(len(heroku)>1)
         self.assertIsInstance(heroku[0], dict)
-        self.assertEqual(heroku[0]["city"], "Asburn")
+        self.assertEqual(heroku[0]["city"], "Ashburn")
         self.assertEqual(heroku[0]["region_code"], "VA")
         self.assertEqual(heroku[0]["country_name"], "United States")
 

--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -49,6 +49,19 @@ class TestUB(unittest.TestCase):
         self.assertEqual(ub.domain_to_geo("github.com")["region_code"], 'CA')
         self.assertEqual(ub.domain_to_geo("github.com")["country_name"], 'United States')
 
+    def test_domain_to_mgeo(self):
+        self.assertIsInstance(ub.domain_to_mgeo("github.com"), list)
+        self.assertEqual(ub.domain_to_geo("github.com")[0]["city"], 'San Francisco')
+        self.assertEqual(ub.domain_to_geo("github.com")[0]["region_code"], 'CA')
+        self.assertEqual(ub.domain_to_geo("github.com")[0]["country_name"], 'United States')
+        heroku = ub.domain_to_mgeo("heroku.com")
+        self.assertIsInstance(heroku, list)
+        self.assertTrue(len(heroku)>1)
+        self.assertIsInstance(heroku[0], dict)
+        self.assertEqual(heroku[0]["city"], "Asburn")
+        self.assertEqual(heroku[0]["region_code"], "VA")
+        self.assertEqual(heroku[0]["country_name"], "United States")
+
     def test_ip_to_geojson(self):
         self.assertIsInstance(ub.ip_to_geojson("192.30.252.130"), dict)
 

--- a/utilitybelt/utilitybelt.py
+++ b/utilitybelt/utilitybelt.py
@@ -17,6 +17,7 @@ import xml.etree.ElementTree as ET
 
 import pygeoip
 import requests
+import warnings
 from bs4 import BeautifulSoup
 from netaddr import IPAddress
 from netaddr import IPNetwork
@@ -152,7 +153,21 @@ def ip_to_geo(ipaddress):
 def domain_to_geo(domain):
     """Convert Domain to Geographic Information"""
 
+    # Check if the domain resolves to multiple addresses and warn
+    # the user and suggest a different method
+    _, _, ips = socket.gethostbyname_ex(domain)
+    if len(ips) > 1:
+        warnings.warn("{domain} resolves to multiple ip addresses,".format(domain=domain), RuntimeWarning)
+
     return gi.record_by_name(domain)
+
+def domain_to_mgeo(domain):
+    """Convert a Domain to Geographic information. Safe for round robin DNS"""
+    locations = []
+    _, _, ips = socket.gethostbyname_ex(domain)
+    for eachIP in ips:
+        locations.append(gi.record_by_addr(eachIP))
+    return locations
 
 
 def ip_to_geojson(ipaddress, name="Point"):

--- a/utilitybelt/utilitybelt.py
+++ b/utilitybelt/utilitybelt.py
@@ -17,6 +17,7 @@ import xml.etree.ElementTree as ET
 
 import pygeoip
 import requests
+import warnings
 from bs4 import BeautifulSoup
 from netaddr import IPAddress
 from netaddr import IPNetwork
@@ -187,7 +188,21 @@ def ip_to_geo(ipaddress):
 def domain_to_geo(domain):
     """Convert Domain to Geographic Information"""
 
+    # Check if the domain resolves to multiple addresses and warn
+    # the user and suggest a different method
+    _, _, ips = socket.gethostbyname_ex(domain)
+    if len(ips) > 1:
+        warnings.warn("{domain} resolves to multiple ip addresses,".format(domain=domain), RuntimeWarning)
+
     return gi.record_by_name(domain)
+
+def domain_to_mgeo(domain):
+    """Convert a Domain to Geographic information. Safe for round robin DNS"""
+    locations = []
+    _, _, ips = socket.gethostbyname_ex(domain)
+    for eachIP in ips:
+        locations.append(gi.record_by_addr(eachIP))
+    return locations
 
 
 def ip_to_geojson(ipaddress, name="Point"):


### PR DESCRIPTION
This came up for discussion in our python code review club meeting earlier this week. The `domain_to_geo` function passes the domain directly to pygeoip which returns a location. However if the domain being searched uses round-robin DNS for some reason then the domain may resolve to multiple IP addresses which could be in several places.

This PR adds a function called `domain_to_mgeo` which will get all the ip addresses that the domain resolves to and then get location info for each of them, returning a list of dictionaries. In order to honor the promises made by previous functions, the existing `domain_to_geo` function continues to work the way it did before but it does raise a warning if a domain resolves to multiple ip addresses.
