### PR TITLE
skips tests that require an API key if that key is not in os.environ

### DIFF
--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -94,7 +94,7 @@ class TestUB(unittest.TestCase):
         self.assertFalse(ub.is_reserved("8.8.4.4"))
         self.assertFalse(ub.is_reserved("192.30.252.131"))
 
-    @unittest.skipIf(os.getenv("VT_API", True), "No VT_API set")
+    @unittest.skipIf(os.getenv("VT_API", None) == None, "No VT_API set")
     def test_vt_ip_check(self):
         vt_api = os.environ["VT_API"]
         self.assertIsNone(ub.vt_ip_check('asdf', vt_api))
@@ -110,7 +110,7 @@ class TestUB(unittest.TestCase):
                 is_gh = True
         self.assertTrue(is_gh)
 
-    @unittest.skipIf(os.getenv("VT_API", True), "No VT_API set")
+    @unittest.skipIf(os.getenv("VT_API", None) == None, "No VT_API set")
     def test_vt_name_check(self):
         vt_api = os.environ["VT_API"]
         self.assertIsNone(ub.vt_name_check('asdf', vt_api))
@@ -139,7 +139,7 @@ class TestUB(unittest.TestCase):
         self.assertIsInstance(tor_data, dict)
         self.assertIn('ProjectHoneypot', tor_data)
 
-    @unittest.skipIf(os.getenv("URLVOID_API", True), "No URLVOID_API set")
+    @unittest.skipIf(os.getenv("URLVOID_API", None) == None, "No URLVOID_API set")
     def test_urlvoid_check(self):
         urlvoid_api = os.environ["URLVOID_API"]
         self.assertIsNone(ub.urlvoid_check('asdf', urlvoid_api))

--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -139,7 +139,7 @@ class TestUB(unittest.TestCase):
         self.assertIsInstance(tor_data, dict)
         self.assertIn('ProjectHoneypot', tor_data)
 
-    @unittest.skipIf(os.getenv("URLVOID_API", True), "No VT_API set")
+    @unittest.skipIf(os.getenv("URLVOID_API", True), "No URLVOID_API set")
     def test_urlvoid_check(self):
         urlvoid_api = os.environ["URLVOID_API"]
         self.assertIsNone(ub.urlvoid_check('asdf', urlvoid_api))

--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -94,6 +94,7 @@ class TestUB(unittest.TestCase):
         self.assertFalse(ub.is_reserved("8.8.4.4"))
         self.assertFalse(ub.is_reserved("192.30.252.131"))
 
+    @unittest.skipIf(os.getenv("VT_API", False)==False, "No VT_API set")
     def test_vt_ip_check(self):
         vt_api = os.environ["VT_API"]
         self.assertIsNone(ub.vt_ip_check('asdf', vt_api))
@@ -109,6 +110,7 @@ class TestUB(unittest.TestCase):
                 is_gh = True
         self.assertTrue(is_gh)
 
+    @unittest.skipIf(os.getenv("VT_API", False)==False, "No VT_API set")
     def test_vt_name_check(self):
         vt_api = os.environ["VT_API"]
         self.assertIsNone(ub.vt_name_check('asdf', vt_api))
@@ -137,6 +139,7 @@ class TestUB(unittest.TestCase):
         self.assertIsInstance(tor_data, dict)
         self.assertIn('ProjectHoneypot', tor_data)
 
+    @unittest.skipIf(os.getenv("URLVOID_API", False)==False, "No VT_API set")
     def test_urlvoid_check(self):
         urlvoid_api = os.environ["URLVOID_API"]
         self.assertIsNone(ub.urlvoid_check('asdf', urlvoid_api))

--- a/utilitybelt/tests/tests.py
+++ b/utilitybelt/tests/tests.py
@@ -94,7 +94,7 @@ class TestUB(unittest.TestCase):
         self.assertFalse(ub.is_reserved("8.8.4.4"))
         self.assertFalse(ub.is_reserved("192.30.252.131"))
 
-    @unittest.skipIf(os.getenv("VT_API", False)==False, "No VT_API set")
+    @unittest.skipIf(os.getenv("VT_API", True), "No VT_API set")
     def test_vt_ip_check(self):
         vt_api = os.environ["VT_API"]
         self.assertIsNone(ub.vt_ip_check('asdf', vt_api))
@@ -110,7 +110,7 @@ class TestUB(unittest.TestCase):
                 is_gh = True
         self.assertTrue(is_gh)
 
-    @unittest.skipIf(os.getenv("VT_API", False)==False, "No VT_API set")
+    @unittest.skipIf(os.getenv("VT_API", True), "No VT_API set")
     def test_vt_name_check(self):
         vt_api = os.environ["VT_API"]
         self.assertIsNone(ub.vt_name_check('asdf', vt_api))
@@ -139,7 +139,7 @@ class TestUB(unittest.TestCase):
         self.assertIsInstance(tor_data, dict)
         self.assertIn('ProjectHoneypot', tor_data)
 
-    @unittest.skipIf(os.getenv("URLVOID_API", False)==False, "No VT_API set")
+    @unittest.skipIf(os.getenv("URLVOID_API", True), "No VT_API set")
     def test_urlvoid_check(self):
         urlvoid_api = os.environ["URLVOID_API"]
         self.assertIsNone(ub.urlvoid_check('asdf', urlvoid_api))


### PR DESCRIPTION
*WARNING* this PR will modify some of the tests so you'll want to check it extra carefully.

Some of the tests will fail if they are run on a system where the environment variables are not set. This change to the `tests.py` file will skip tests that depend on `VT_API` or `URLVOID_API` if those environment variables are not set.