### PR TITLE
catch exceptions in reverse_dns for herror and gaierror

### DIFF
--- a/utilitybelt/utilitybelt.py
+++ b/utilitybelt/utilitybelt.py
@@ -275,10 +275,18 @@ def reverse_dns_sna(ipaddress):
 
 
 def reverse_dns(ipaddress):
-    """Returns a list of the dns names that point to a given ipaddress"""
+    """Returns a list of the dns names that point to a given ipaddress.
+       An empty list will be returned for IP addresses without a PTR record,
+       or invalid IP addresses that throw a socket.gaierror exception."""
 
-    name = socket.gethostbyaddr(ipaddress)[0]
-    return [str(name)]
+    try:
+        name = socket.gethostbyaddr(ipaddress)[0]
+        hosts = [str(name)]
+
+    except (socket.herror, socket.gaierror):
+        hosts = []
+
+    return hosts
 
 
 def vt_ip_check(ip, vt_api):


### PR DESCRIPTION
This patches the `reverse_dns()` function to return an empty list if a socket.herror or socket.gaierror is caught.

```
>>> from utilitybelt import utilitybelt as ub

## This throws a socket.gaierror exception since the IP address contains a newline.
>>> ub.reverse_dns('50.116.59.164\n')
[]

## This is a valid lookup
>>> ub.reverse_dns('50.116.59.164')
['zeroharbor.org']

## This throws a socket.herror exception since there's no PTR record
>>> ub.reverse_dns('82.160.51.229')
[]
>>>
```
